### PR TITLE
Use internal variable to check for vim-dispatch

### DIFF
--- a/autoload/cmake/util.vim
+++ b/autoload/cmake/util.vim
@@ -75,7 +75,7 @@ function! cmake#util#run_cmake(command, binary_dir, source_dir)
 endfunc
 
 function! cmake#util#shell_exec(command)
-  if g:loaded_dispatch == 1
+  if g:cmake_use_dispatch == 1
     return dispatch#compile_command(0, a:command, 0)
   else
     return system(a:command)
@@ -83,7 +83,7 @@ function! cmake#util#shell_exec(command)
 endfunc
 
 function! cmake#util#shell_bgexec(command)
-  if g:loaded_dispatch == 1
+  if g:cmake_use_dispatch == 1
     call dispatch#start(a:command, {'background': 1})
   else
     call cmake#util#shell_exec(a:command)


### PR DESCRIPTION
CMakeCreateBuild will fail without vim-dispatch installed with the following error. It seems it was set up to fix this by setting g:cmake_use_dispatch on load, but the code didn't use the internal variable.

```
[cmake] Configuring project for the first time...
Error detected while processing function cmake#commands#create_build..cmake#util
#run_cmake..cmake#util#shell_exec:
line    1:
E121: Undefined variable: g:loaded_dispatch
E15: Invalid expression: g:loaded_dispatch == 1
```
