### PR TITLE
Remove extra argument to dispatch#compile_command

### DIFF
--- a/autoload/cmake/util.vim
+++ b/autoload/cmake/util.vim
@@ -76,7 +76,7 @@ endfunc
 
 function! cmake#util#shell_exec(command)
   if g:loaded_dispatch == 1
-    return dispatch#compile_command(0, a:command, 0)
+    return dispatch#compile_command(0, a:command)
   else
     return system(a:command)
   endif


### PR DESCRIPTION
The third argument to `dispatch#compile_command` was causing a "Too many
arguments for function" error. I'm not sure how this snuck in, as AFAICT
the signature of compile_command has been constant since
tpope/vim-dispatch@ef6ac42.
